### PR TITLE
YK-VERIFIER 111 Update time between doses to be greater than or equals to

### DIFF
--- a/shcDecoder/src/main/java/ca/bc/gov/shcdecoder/SHCVerifierImpl.kt
+++ b/shcDecoder/src/main/java/ca/bc/gov/shcdecoder/SHCVerifierImpl.kt
@@ -18,6 +18,7 @@ import ca.bc.gov.shcdecoder.repository.PreferenceRepository
 import ca.bc.gov.shcdecoder.rule.RulesManager
 import ca.bc.gov.shcdecoder.rule.impl.RulesManagerImpl
 import ca.bc.gov.shcdecoder.utils.addDays
+import ca.bc.gov.shcdecoder.utils.inclusiveAfter
 import ca.bc.gov.shcdecoder.utils.toDate
 import ca.bc.gov.shcdecoder.validator.JWKSValidator
 import ca.bc.gov.shcdecoder.validator.impl.JWKSValidatorImpl
@@ -188,7 +189,7 @@ class SHCVerifierImpl(
 
         val expectedDate = lastDoseTime.addDays(daysSinceLastInterval)
 
-        return currentDoseTime?.after(expectedDate) == true
+        return currentDoseTime?.inclusiveAfter(expectedDate) == true
     }
 
     private fun intervalPassed(date: Date?, daysSinceLastInterval: Int): Boolean {

--- a/shcDecoder/src/main/java/ca/bc/gov/shcdecoder/utils/Extensions.kt
+++ b/shcDecoder/src/main/java/ca/bc/gov/shcdecoder/utils/Extensions.kt
@@ -37,3 +37,9 @@ fun Date.addDays(day: Int): Date? {
     calendar.add(Calendar.DATE, day)
     return Date(calendar.timeInMillis)
 }
+
+fun Date.inclusiveAfter(other: Date?): Boolean {
+    return other?.let {
+        this.time >= other.time
+    } ?: false
+}


### PR DESCRIPTION
**The Yukon Gov’t would like the adjust the interpretation of the ‘time between doeses’ to be inclusive of the vaccination date**

The real reason behind this problem is that the date of vaccinations doesn't include hours and minutes, this leads to weird behaviour in calculations using the after method because it will use defaults 00:00 Hrs.

However, since is not possible to fix that without altering the entire project I did a more smaller approach, which is tecnically correct and accord with the ticket description.

I just added a new method that completely emulates the original after method but with greater or equals operator. Works like a charm.

https://freshworks.atlassian.net/browse/YKVERIFIER-111