### PR TITLE
yk-verifier 114 Decode timeboxed QR codes

### DIFF
--- a/shcDecoder/src/main/java/ca/bc/gov/shcdecoder/model/SHCPayload.kt
+++ b/shcDecoder/src/main/java/ca/bc/gov/shcdecoder/model/SHCPayload.kt
@@ -9,5 +9,6 @@ package ca.bc.gov.shcdecoder.model
 data class SHCPayload(
     val iss: String,
     val nbf: Double,
-    val vc: Vc
+    val vc: Vc,
+    val exp: Double?
 )


### PR DESCRIPTION
The government of Yukon, using the SMART Health Card issuer, will be able to begin issuing temporary PVC to visitors. These PVCs will expire on a certain date/time, as determined by the issuer (new keyname: exp). The Yukon Government would like the app to appropriately decode the new keyname, and indicate that it is an ‘Invalid QR’ once the PVC has expired.  

In order to make this possible I had to add the new value to the payload model, also I did some validations. Since the value comes in epoch time (seconds instead of milliseconds) the method to evaluate this exp time multiplies the value and then performs the validation, if not zero and current date is after exp time then send invalid qr.

For more info:
https://freshworks.atlassian.net/browse/YKVERIFIER-114