### PR TITLE
Bugfix Invalid QR Message

### DIFF
--- a/app/src/main/java/ca/bc/gov/vaxcheck/di/DecoderModule.kt
+++ b/app/src/main/java/ca/bc/gov/vaxcheck/di/DecoderModule.kt
@@ -72,7 +72,7 @@ class DecoderModule {
         SHCConfig(
             context.getString(R.string.issuer_url),
             context.getString(R.string.rules_url),
-            " ",
+            context.getString(R.string.deferrals_domain),
             defaultJWKSKeys,
             rules,
             if (BuildConfig.FLAVOR == "prod") PROD_EXPIRY_TIME else TEST_EXPIRY_TIME

--- a/app/src/main/java/ca/bc/gov/vaxcheck/ui/scanner/BarcodeScannerFragment.kt
+++ b/app/src/main/java/ca/bc/gov/vaxcheck/ui/scanner/BarcodeScannerFragment.kt
@@ -25,7 +25,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
-import ca.bc.gov.shcdecoder.model.ImmunizationStatus
 import ca.bc.gov.shcdecoder.model.VaccinationStatus
 import ca.bc.gov.vaxcheck.R
 import ca.bc.gov.vaxcheck.barcodeanalyzer.BarcodeAnalyzer
@@ -148,6 +147,7 @@ class BarcodeScannerFragment : Fragment(R.layout.fragment_barcode_scanner), Scan
                     )
                 }
 
+                VaccinationStatus.NOT_VACCINATED,
                 VaccinationStatus.INVALID -> {
                     onFailure()
                 }

--- a/app/src/main/java/ca/bc/gov/vaxcheck/ui/scanresult/BarcodeScanResultFragment.kt
+++ b/app/src/main/java/ca/bc/gov/vaxcheck/ui/scanresult/BarcodeScanResultFragment.kt
@@ -71,7 +71,7 @@ class BarcodeScanResultFragment : Fragment(R.layout.fragment_barcode_scan_result
                                 findNavController().popBackStack()
                             }
                     }
-                    VaccinationStatus.INVALID -> {
+                    else -> {
                         sceneNoRecord.enter()
                         sceneNoRecord.sceneRoot.findViewById<View>(R.id.buttonScanNext)
                             .setOnClickListener {

--- a/shcDecoder/src/main/java/ca/bc/gov/shcdecoder/SHCVerifierImpl.kt
+++ b/shcDecoder/src/main/java/ca/bc/gov/shcdecoder/SHCVerifierImpl.kt
@@ -205,7 +205,7 @@ class SHCVerifierImpl(
         return if (mrnType + nrvvType + winacType > 0) {
             VaccinationStatus.PARTIALLY_VACCINATED
         } else {
-            VaccinationStatus.INVALID
+            VaccinationStatus.NOT_VACCINATED
         }
     }
 

--- a/shcDecoder/src/main/java/ca/bc/gov/shcdecoder/model/VaccinationStatus.kt
+++ b/shcDecoder/src/main/java/ca/bc/gov/shcdecoder/model/VaccinationStatus.kt
@@ -6,5 +6,6 @@ package ca.bc.gov.shcdecoder.model
 enum class VaccinationStatus {
     FULLY_VACCINATED,
     PARTIALLY_VACCINATED,
+    NOT_VACCINATED,
     INVALID
 }


### PR DESCRIPTION
To explain a little bit, in the Yukon Vaccination App, the client requires that, in the case the QR is correctly done and issued, but have no vaccines or exempts, the app displays "Does not meet requirements" fragment screen instead of the "Invalid QR" pop up dialog message, recenty I were also told that they want the Invalid Qr popup message to be shown too when the QR is not correctly issued, which makes sense.

So, these changed I made in the decoder library are a preparation for that scenario in the Yukon App. I didn't do major changes in the BCVAX Code. since the "Does not meet requirements" screen doesn't completely exists there.